### PR TITLE
Use absolute paths for the filenames when traversing the graph so tha…

### DIFF
--- a/conda_devenv/devenv.py
+++ b/conda_devenv/devenv.py
@@ -33,6 +33,7 @@ def handle_includes(root_filename, root_yaml):
             continue
 
         for included_filename in yaml_dict.get("includes", []):
+            included_filename = os.path.abspath(included_filename)
             if not os.path.isfile(included_filename):
                 raise ValueError(
                     "Couldn't find the file '{included_filename}' "
@@ -294,6 +295,7 @@ def main():
     args = parser.parse_args()
 
     filename = args.file
+    filename = os.path.abspath(filename)
 
     conda_yaml_dict, environment = load_yaml_dict(filename)
     rendered_contents = render_for_conda_env(conda_yaml_dict)

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -1,4 +1,6 @@
 import pytest
+import os
+
 import yaml
 
 from conda_devenv.devenv import handle_includes, render_jinja
@@ -12,7 +14,10 @@ def obtain_yaml_dicts(root_yaml_filename):
     dicts = list(dicts)
 
     # The list order does not matter, so we can"t use indices to fetch each item
+    number_of_parsed_yamls = len(dicts)
     dicts = {d["name"]: d for d in dicts}
+    # Make sure we're not removing any parsed yamls
+    assert len(dicts) == number_of_parsed_yamls
     return dicts
 
 
@@ -85,3 +90,16 @@ def test_include_non_existent_file(datadir):
         obtain_yaml_dicts(datadir["includes_non_existent_file.yml"])
     assert "includes_non_existent_file.yml" in str(e)
     assert "non_existent_file.yml" in str(e)
+
+
+def test_include_file_with_relative_includes(datadir):
+    datadir["proj1"]
+    datadir["proj2"]
+    datadir["proj1/relative_include.yml"]
+    datadir["proj2/relative_include.yml"]
+    datadir["set_variable.yml"]
+
+    dicts = obtain_yaml_dicts(datadir["proj1/relative_include.yml"])
+
+    assert len(dicts) == 3
+    assert sorted(dicts.keys()) == ["proj1", "proj2", "set_variable"]

--- a/tests/test_include/proj1/relative_include.yml
+++ b/tests/test_include/proj1/relative_include.yml
@@ -1,0 +1,4 @@
+name: proj1
+includes:
+  - {{ root }}/../proj2/relative_include.yml
+  - {{ root }}/../set_variable.yml

--- a/tests/test_include/proj2/relative_include.yml
+++ b/tests/test_include/proj2/relative_include.yml
@@ -1,0 +1,3 @@
+name: proj2
+includes:
+  - {{ root }}/../set_variable.yml

--- a/tests/test_include/set_variable.yml
+++ b/tests/test_include/set_variable.yml
@@ -1,0 +1,3 @@
+name: set_variable
+environment:
+  VARIABLE: value


### PR DESCRIPTION
If the files are kept as is, they may contain relative paths, and other files may include them in other ways, so the same file would be included twice, even though they are actually the same file.