### PR TITLE
Fixes to activate/deactivate bash scripts

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
 History
 =======
 
+0.9.1 (2017-03-22)
+------------------
+
+* Fix activate and deactivate ``bash`` scripts: variables not in the environment before activation
+  are now properly unset after deactivation.
+
+* Fix activate and deactivate ``bash`` scripts: quote variables when exporting them.
+
 
 0.9.0 (2017-03-17)
 ------------------

--- a/conda_devenv/devenv.py
+++ b/conda_devenv/devenv.py
@@ -157,7 +157,9 @@ def render_activate_script(environment, shell):
                 # Lists are supposed to prepend to the existing value
                 value = pathsep.join(value) + pathsep + "${variable}".format(variable=variable)
 
-            script.append("export CONDA_DEVENV_BKP_{variable}=${variable}".format(variable=variable))
+            script.append("if [ ! -z ${{{variable}+x}} ]; then".format(variable=variable))
+            script.append("    export CONDA_DEVENV_BKP_{variable}=\"${variable}\"".format(variable=variable))
+            script.append("fi")
             script.append("export {variable}=\"{value}\"".format(variable=variable, value=value))
 
         elif shell == "cmd":
@@ -203,8 +205,12 @@ def render_deactivate_script(environment, shell='bash'):
 
     for variable in sorted(environment):
         if shell == "bash":
-            script.append("export {variable}=$CONDA_DEVENV_BKP_{variable}".format(variable=variable))
-            script.append("unset CONDA_DEVENV_BKP_{variable}".format(variable=variable))
+            script.append("if [ ! -z ${{CONDA_DEVENV_BKP_{variable}+x}} ]; then".format(variable=variable))
+            script.append("    export {variable}=\"$CONDA_DEVENV_BKP_{variable}\"".format(variable=variable))
+            script.append("    unset CONDA_DEVENV_BKP_{variable}".format(variable=variable))
+            script.append("else")
+            script.append("    unset {variable}".format(variable=variable))
+            script.append("fi")
 
         elif shell == "cmd":
             script.append("set \"{variable}=%CONDA_DEVENV_BKP_{variable}%\"".format(variable=variable))

--- a/tests/test_environment_scripts.py
+++ b/tests/test_environment_scripts.py
@@ -23,29 +23,47 @@ def test_render_activate_and_deactivate_scripts_bash(single_values, multiple_val
     # activate
     assert render_activate_script(single_values, "bash") == textwrap.dedent("""\
         #!/bin/bash
-        export CONDA_DEVENV_BKP_VALUE=$VALUE
+        if [ ! -z ${VALUE+x} ]; then
+            export CONDA_DEVENV_BKP_VALUE="$VALUE"
+        fi
         export VALUE="value"
         """).strip()
     assert render_activate_script(multiple_values, "bash") == textwrap.dedent("""\
         #!/bin/bash
-        export CONDA_DEVENV_BKP_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+        if [ ! -z ${LD_LIBRARY_PATH+x} ]; then
+            export CONDA_DEVENV_BKP_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
+        fi
         export LD_LIBRARY_PATH="path_a:path_b:$LD_LIBRARY_PATH"
-        export CONDA_DEVENV_BKP_PATH=$PATH
+        if [ ! -z ${PATH+x} ]; then
+            export CONDA_DEVENV_BKP_PATH="$PATH"
+        fi
         export PATH="path_a:path_b:$PATH"
         """).strip()
 
     # deactivate
     assert render_deactivate_script(single_values, "bash") == textwrap.dedent("""\
         #!/bin/bash
-        export VALUE=$CONDA_DEVENV_BKP_VALUE
-        unset CONDA_DEVENV_BKP_VALUE
+        if [ ! -z ${CONDA_DEVENV_BKP_VALUE+x} ]; then
+            export VALUE="$CONDA_DEVENV_BKP_VALUE"
+            unset CONDA_DEVENV_BKP_VALUE
+        else
+            unset VALUE
+        fi
         """).strip()
     assert render_deactivate_script(multiple_values, "bash") == textwrap.dedent("""\
         #!/bin/bash
-        export LD_LIBRARY_PATH=$CONDA_DEVENV_BKP_LD_LIBRARY_PATH
-        unset CONDA_DEVENV_BKP_LD_LIBRARY_PATH
-        export PATH=$CONDA_DEVENV_BKP_PATH
-        unset CONDA_DEVENV_BKP_PATH
+        if [ ! -z ${CONDA_DEVENV_BKP_LD_LIBRARY_PATH+x} ]; then
+            export LD_LIBRARY_PATH="$CONDA_DEVENV_BKP_LD_LIBRARY_PATH"
+            unset CONDA_DEVENV_BKP_LD_LIBRARY_PATH
+        else
+            unset LD_LIBRARY_PATH
+        fi
+        if [ ! -z ${CONDA_DEVENV_BKP_PATH+x} ]; then
+            export PATH="$CONDA_DEVENV_BKP_PATH"
+            unset CONDA_DEVENV_BKP_PATH
+        else
+            unset PATH
+        fi
         """).strip()
 
 


### PR DESCRIPTION
* Fix activate and deactivate ``bash`` scripts: variables not in the environment before activation
  are not properly unset after deactivation.

* Fix activate and deactivate ``bash`` scripts: quote variables when exporting them.