### PR TITLE
Simplify conda develop command

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -65,7 +65,7 @@ Ready to contribute? Here's how to set up `conda-devenv` for local development.
 3. Create a new conda environment for developing::
 
     $ conda create -n devenv --file requirements_dev.txt
-    $ conda develop %CD%\conda_devenv
+    $ conda develop conda_devenv
 
 4. Create a branch for local development::
 


### PR DESCRIPTION
@tadeu is right, you can pass just the directory and conda will write the full path:

```
λ conda develop conda_devenv
added e:\ws\General\Projects\conda-devenv\conda_devenv
completed operation for: e:\ws\General\Projects\conda-devenv\conda_devenv
```

Follow up from: https://github.com/ESSS/conda-devenv/pull/38#discussion_r108240973