### PR TITLE
Find correct env through 'envs_dir' instead of matching first found i…

### DIFF
--- a/conda_devenv/devenv.py
+++ b/conda_devenv/devenv.py
@@ -456,10 +456,12 @@ def get_env_directory(env_name):
     import json
     info = subprocess.check_output(["conda", "info", "--json"]).decode()
     info = json.loads(info)
-    envs = info["envs"]
+    envs_dirs = info["envs_dirs"]
 
-    for env in envs:
-        if os.path.basename(env) == env_name:
+    for directory in envs_dirs:
+        env = os.path.join(directory, env_name)
+        conda_meta_dir = os.path.join(env, 'conda-meta')
+        if os.path.isdir(conda_meta_dir) and os.path.basename(env) == env_name:
             return env
 
     return None

--- a/conda_devenv/devenv.py
+++ b/conda_devenv/devenv.py
@@ -461,8 +461,8 @@ def get_env_directory(env_name):
     for directory in envs_dirs:
         env = os.path.join(directory, env_name)
         conda_meta_dir = os.path.join(env, 'conda-meta')
-        if os.path.isdir(conda_meta_dir) and os.path.basename(env) == env_name:
-            return env
+        if os.path.isdir(conda_meta_dir):
+            return os.path.normpath(env)
 
     return None
 


### PR DESCRIPTION
Old code was checking for all envs listed in "envs" and picking the first one that matched the env name, but this was leading to a wrong match in some situations. Now we look for a match in the existing "env_dirs" and make an extra confirmation by checking if "conda-meta" dir exists.