### PR TITLE
Obtain the envs dir directly from conda without using a subprocess

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
 History
 =======
 
+Next
+------------------
+
+* Obtain  ``envs_dir`` without using a subprocess (`#67`_).
+
+
+.. _`#67`: https://github.com/ESSS/conda-devenv/issues/67
+
 1.0.3 (2018-06-20)
 ------------------
 

--- a/conda_devenv/devenv.py
+++ b/conda_devenv/devenv.py
@@ -451,12 +451,17 @@ def get_env_name(args, output_filename, conda_yaml_dict=None):
     return conda_yaml_dict['name']
 
 
+def _get_envs_dirs_from_conda():
+    from conda.base.context import context
+    return context.envs_dirs
+
+
 def get_env_directory(env_name):
-    import subprocess
-    import json
-    info = subprocess.check_output(["conda", "info", "--json"]).decode()
-    info = json.loads(info)
-    envs_dirs = info["envs_dirs"]
+    """
+    :rtype: Optional[str]
+    :return: The environment path if the enviromment exists.
+    """
+    envs_dirs = _get_envs_dirs_from_conda()
 
     for directory in envs_dirs:
         env = os.path.join(directory, env_name)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -140,14 +140,14 @@ def test_get_env_directory(mocker, tmpdir):
     env_1 = tmpdir.join('1/envs/my_env').ensure(dir=1)
     conda_meta_env_1 = tmpdir.join('1/envs/my_env/conda-meta').ensure(dir=1)
 
-    # Replacing separators because of Windows
-    mock_output = '''
-        {{
-        "envs": ["{0}", "{1}"],
-        "envs_dirs": ["{2}"]
-        }}
-    '''.format(str(env_0), str(env_1), str(tmpdir.join('1/envs'))).replace('\\','\\\\').encode()
-    mocker.patch('subprocess.check_output', return_value=mock_output)
+    mocker.patch('subprocess.check_output', side_effect=AssertionError())
+    mocker.patch.object(
+        devenv, '_get_envs_dirs_from_conda',
+        return_value=[
+            str(tmpdir.join('0/envs')),
+            str(tmpdir.join('1/envs')),
+        ],
+    )
 
     obtained = devenv.get_env_directory('my_env')
     assert obtained == str(env_1)


### PR DESCRIPTION
This should fix #67 