### PR TITLE
Add support for min_conda_devenv_version jinja function

### DIFF
--- a/conda_devenv/devenv.py
+++ b/conda_devenv/devenv.py
@@ -25,6 +25,20 @@ def preprocess_selectors(contents):
     return '\n'.join(lines)
 
 
+def _min_conda_devenv_version(min_version):
+    """Checks that the current conda devenv version is at least the given version"""
+    from distutils.version import LooseVersion
+    import conda_devenv
+
+    if LooseVersion(conda_devenv.__version__) < LooseVersion(min_version):
+        msg = 'This file requires at minimum conda-devenv {}, but you have {} installed.\n'
+        sys.stderr.write(msg.format(min_version, conda_devenv.__version__))
+        sys.stderr.write('Please update conda-devenv.\n')
+        raise SystemExit(1)
+
+    return ''
+
+
 def render_jinja(contents, filename, is_included):
     import jinja2
     import sys
@@ -53,6 +67,7 @@ def render_jinja(contents, filename, is_included):
         "win": iswin,
         "win32": iswin and is32bit,
         "win64": iswin and is64bit,
+        "min_conda_devenv_version": _min_conda_devenv_version,
     }
 
     contents = preprocess_selectors(contents)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -72,6 +72,30 @@ The following variables are available in the Jira 2 namespace:
      - True if the platform is Windows and the Python architecture is 64-bit.
 
 
+Checking minimum conda-devenv version
+-------------------------------------
+
+If your ``environment.devenv.yml`` files make use of features available only in later ``conda-devenv`` versions,
+you can specify a minimum  version using the ``min_conda_devenv_version`` function at the top of your file:
+
+.. code-block:: yaml
+
+    {{ min_conda_devenv_version("1.1") }}
+    name: web-ui
+
+
+If users are using an old version, they will get then an error message indicating that they should update
+their ``conda-devenv`` version.
+
+It is recommended to use this setting to avoid confusing errors of users updating your software when new
+``conda-devenv`` features are used.
+
+.. note::
+
+    Unfortunately this feature was added in ``conda-devenv 1.1``, so ``1.0`` users will get a more cryptic message
+    about ``min_conda_devenv_version`` not being defined.
+
+
 Environment Variables
 =====================
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -107,6 +107,38 @@ def test_print_full(tmpdir, capsys):
     assert 'PYTHONPATH:' in out
 
 
+def test_min_version_failure(tmpdir, capsys):
+    """
+    Check the "min_conda_devenv_version()" fails with the expected message.
+    """
+    import conda_devenv
+    filename = tmpdir.join('environment.devenv.yml')
+    filename.write(textwrap.dedent('''\
+        {{ min_conda_devenv_version("999.9") }}
+        name: a                
+    '''))
+    with pytest.raises(SystemExit) as e:
+        devenv.main(['--file', str(filename)])
+    assert e.value.code == 1
+    out, err = capsys.readouterr()
+    assert out == ''
+    msg = 'This file requires at minimum conda-devenv 999.9, but you have {ver} installed.'
+    assert msg.format(ver=conda_devenv.__version__) in err
+
+
+def test_min_version_ok(tmpdir, capsys):
+    """
+    Check the "min_conda_devenv_version()" does not fail with current version.
+    """
+    import conda_devenv
+    filename = tmpdir.join('environment.devenv.yml')
+    filename.write(textwrap.dedent('''\
+        {{{{ min_conda_devenv_version("{}") }}}}
+        name: a                
+    '''.format(conda_devenv.__version__)))
+    assert devenv.main(['--file', str(filename), '--print-full']) == 0
+
+
 def test_version(capsys):
     """
     Test --version flag.


### PR DESCRIPTION
This allows authors to specify a minimum conda-devenv version in case their
files use newer conda-devenv features, providing users with a clear message if
they are using old versions.

I think we should add this to `1.1` to get to use this immediately.