### PR TITLE
Add jinja2 functions env and versionformat

### DIFF
--- a/conda_devenv/devenv.py
+++ b/conda_devenv/devenv.py
@@ -39,6 +39,19 @@ def _min_conda_devenv_version(min_version):
     return ''
 
 
+def _env(name):
+    """Alias for os.environ.get method"""
+    return os.environ.get(name)
+
+
+def _versionformat(ver):
+    """Convert string `ver` to a semantic version formatted string if not already"""
+    # Case 1: if ver is '372' (string without dots), return '3.7.2'
+    # Case 2: if ver is '3.7.2' (string with dots), return ver (in this case, '3.7.2')
+    # Case 3: if ver is None, return None
+    return '.'.join(ver) if ver and '.' not in ver else ver
+
+
 def render_jinja(contents, filename, is_included):
     import jinja2
     import sys
@@ -68,6 +81,8 @@ def render_jinja(contents, filename, is_included):
         "win32": iswin and is32bit,
         "win64": iswin and is64bit,
         "min_conda_devenv_version": _min_conda_devenv_version,
+        "env": _env,
+        "versionformat": _versionformat
     }
 
     contents = preprocess_selectors(contents)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -16,15 +16,17 @@ based python version, etc. For example:
 
 .. code-block:: yaml
 
-    {% set conda_py = os.environ.get('CONDA_PY', '35') %}
+    {% set conda_py = env('CONDA_PY') or '35' %}
+
     name: web-ui-py{{ conda_py }}
 
     dependencies:
+      - python={{ versionformat(conda_py) }}
       - boost
       - cmake
-      - gcc     # [linux]
-      - ccache  # [not win]
-      - clcache # [win] Windows has clcache
+      - gcc        # [linux]
+      - ccache     # [not win]
+      - clcache    # [win]
 
 Note that in the example above, we are able to define dependency requirements
 that are specific to Linux, macOS, and Windows (e.g., ``ccache`` is needed in
@@ -37,7 +39,7 @@ most useful capabilities of ``conda-devenv``.
   inside the brackets following the YAML comment mark ``#``. For example,
   ``# [linux]`` could be replaced with ``# [sys.platform.startswith('linux')]``.
 
-The following variables are available in the Jinja 2 namespace:
+The following variables and functions are available in the Jinja 2 namespace:
 
 .. list-table::
    :widths: 20 80
@@ -50,6 +52,13 @@ The following variables are available in the Jinja 2 namespace:
      - The standard Python module object ``sys`` obtained with ``import sys``.
    * - ``platform``
      - The standard Python module object ``platform`` obtained with ``import platform``.
+   * - ``env``
+     - Function to get environment variables (e.g., ``env('CONDA_PY')``).
+   * - ``versionformat``
+     - Function to perform semantic version formatting (e.g., ``versionformat('37')`` returns
+       ``'3.7'``, while ``versionformat('3.7.5')`` returns ``'3.7.5'``).
+       Useful when version information is formatted as integers (e.g., ``27`` and ``3.5``
+       instead of ``2.7`` and ``3.5``).
    * - ``x86``
      - True if the system architecture is x86, both 32-bit and 64-bit, for Intel or AMD chips.
    * - ``x86_64``

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -183,6 +183,33 @@ def test_jinja_win64(monkeypatch):
     assert render_jinja(template, filename="", is_included=False) == 'True'
 
 
+def test_jinja_env(monkeypatch):
+
+    template = "{{ env('VAR') }}"
+
+    monkeypatch.setattr(os, 'environ', { 'VAR': '10' })
+    assert render_jinja(template, filename="", is_included=False) == '10'
+
+    template = "{{ env('NON_EXISTING_VAR') }}"
+    monkeypatch.setattr(os, 'environ', {})
+    assert render_jinja(template, filename="", is_included=False) == 'None'
+
+
+def test_jinja_versionformat(monkeypatch):
+
+    template = "{{ versionformat('12') }}"
+    assert render_jinja(template, filename="", is_included=False) == '1.2'
+
+    template = "{{ versionformat('1.2.12') }}"
+    assert render_jinja(template, filename="", is_included=False) == '1.2.12'
+
+    template = "{{ versionformat(None) }}"
+    assert render_jinja(template, filename="", is_included=False) == 'None'
+
+    template = "{{ versionformat('') }}"
+    assert render_jinja(template, filename="", is_included=False) == ''
+
+
 def test_preprocess_selector_in_line():
     line = "  - ccache    # [linux or osx]"
     expected = "{{% if linux or osx %}}{0}{{% endif %}}".format(line)


### PR DESCRIPTION
This PR proposes the addition of two functions in the jinja2 dictionary of variables. They are `env` and `versionformat`.

- The function `env` is just a syntactic sugar to `os.environt.get` method.
- The function `versionformat` is useful when version information is available in integer format, but a semantic version format is needed (e.g., `37` instead of `3.7`).

With the proposed changes, the following conda-devenv yaml file:

~~~yaml
{% set conda_py = os.environ.get('CONDA_PY', '35') %}

name: web-ui-py{{ conda_py }}

dependencies:
  - python={{ '.'.join(conda_py) }}
  - boost
  - cmake
  - gcc     # [linux]
  - ccache  # [not win]
  - clcache # [win]
~~~

becomes:

~~~yaml
{% set conda_py = env('CONDA_PY') or '35' %}

name: web-ui-py{{ conda_py }}

dependencies:
  - python={{ versionformat(conda_py) }}
  - boost
  - cmake
  - gcc        # [linux]
  - ccache     # [not win]
  - clcache    # [win]
~~~