### PR TITLE
Crude fix for issue #91 with pip dependences.

### DIFF
--- a/conda_devenv/devenv.py
+++ b/conda_devenv/devenv.py
@@ -206,16 +206,21 @@ def merge_dependencies_version_specifications(yaml_dict, key_to_merge,
                     dep, key_to_merge=key, pip=(key == 'pip'))
             new_dict_dependencies.append(dep)
         elif isinstance(dep, six.string_types):
-            m = re.match(package_pattern, dep)
-            if m is None:
-                raise RuntimeError('The package version specification "{}" do not follow the'
-                                   ' expected format.'.format(dep))
-            # Consider the channel name as part of the package name. If multiple channels are specified, the package
-            # will be repeated.
             if pip and ("+" in dep or ":" in dep):
+                # Look for dependencies in the pip section that are
+                # managed by version control.  For example:
+                #   hg+ssh://hg@bitbucket.org/mforbes/mmfutils-fork@0.4.12
+                # Skip processing these and just pass them through
                 package_name = dep
-                package_version = []
+                package_version = ''
             else:
+                m = re.match(package_pattern, dep)
+                if m is None:
+                    raise RuntimeError(
+                        'The package version specification "{}" do not follow the'
+                        ' expected format.'.format(dep))
+                # Consider the channel name as part of the package name.
+                # If multiple channels are specified, the package will be repeated.
                 package_name = m.group('package')
                 if m.group('channel'):
                     package_name = m.group('channel') + package_name

--- a/conda_devenv/devenv.py
+++ b/conda_devenv/devenv.py
@@ -182,7 +182,8 @@ def merge(dicts, keys_to_skip=('name',)):
     return final_dict
 
 
-def merge_dependencies_version_specifications(yaml_dict, key_to_merge):
+def merge_dependencies_version_specifications(yaml_dict, key_to_merge,
+                                              pip=False):
     import collections
     import re
     value_to_merge = yaml_dict.get(key_to_merge, None)
@@ -201,7 +202,8 @@ def merge_dependencies_version_specifications(yaml_dict, key_to_merge):
     for dep in value_to_merge:
         if isinstance(dep, dict):
             for key in dep:
-                merge_dependencies_version_specifications(dep, key_to_merge=key)
+                merge_dependencies_version_specifications(
+                    dep, key_to_merge=key, pip=(key == 'pip'))
             new_dict_dependencies.append(dep)
         elif isinstance(dep, six.string_types):
             m = re.match(package_pattern, dep)
@@ -210,14 +212,20 @@ def merge_dependencies_version_specifications(yaml_dict, key_to_merge):
                                    ' expected format.'.format(dep))
             # Consider the channel name as part of the package name. If multiple channels are specified, the package
             # will be repeated.
-            package_name = m.group('package')
-            if m.group('channel'):
-                package_name = m.group('channel') + package_name
+            if pip and ("+" in dep or ":" in dep):
+                package_name = dep
+                package_version = []
+            else:
+                package_name = m.group('package')
+                if m.group('channel'):
+                    package_name = m.group('channel') + package_name
+
+                package_version = m.group('version')
 
             # OrderedDict is used as an ordered set, the value is ignored.
             version_matchers = new_dependencies.setdefault(package_name, collections.OrderedDict())
-            if len(m.group('version')) > 0:
-                version_matchers[m.group('version')] = True
+            if len(package_version) > 0:
+                version_matchers[package_version] = True
         else:
             raise RuntimeError("Only strings and dicts are supported, got: {!r}".format(dep))
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,4 +1,7 @@
+import copy
+
 import pytest
+
 from conda_devenv.devenv import merge, merge_dependencies_version_specifications, \
     separate_strings_from_dicts
 
@@ -180,6 +183,22 @@ def test_merge_dependencies_version_specifications_errors():
     with pytest.raises(RuntimeError, match='.*Only strings and dicts are supported.*'):
         merge_dependencies_version_specifications(merged_dict, key_to_merge='dependencies')
 
+
+def test_merge_dependencies_version_specifications_pip_dependencies():
+    """Regression test for issue #91."""
+    merged_dict = {
+        "dependencies": [
+            'pip',
+            {'pip': [
+                'hg+ssh://hg@bitbucket.org/mforbes/mmfutils-fork@0.4.12',
+                'hg+ssh://hg@bitbucket.org/mforbes/pytimeode@0.9']}
+        ]
+    }
+    merged_dict_ = copy.deepcopy(merged_dict)
+    merge_dependencies_version_specifications(
+        merged_dict, key_to_merge='dependencies')
+    assert merged_dict_ == merged_dict
+    
 
 def test_merge_error_can_not_merge():
     with pytest.raises(ValueError, match='.*because it will override the previous value.*'):


### PR DESCRIPTION
Here we simply do not process the entries in the pip section if they
contain "+" or ":".