### PR TITLE
Fix relative include without root jinja root

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 ------------------
 
 * Drop support for Python 2.7, 3.4, and 3.5.
+* Correctly parse relative includes without jinja root.
 
 
 1.1.3 (2019-12-26)

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -76,6 +76,18 @@ def test_include_file_with_relative_includes(datadir):
     assert sorted(dicts.keys()) == ["proj1", "proj2", "set_variable"]
 
 
+def test_include_relative_to_env_filename(datadir, monkeypatch):
+    monkeypatch.chdir(datadir / "proj1")
+    dicts = obtain_yaml_dicts(str(datadir / "relative_includes.yml"))
+    assert len(dicts) == 4
+    assert sorted(dicts.keys()) == [
+        "non_root_relative",
+        "proj1",
+        "proj2",
+        "set_variable",
+    ]
+
+
 def test_include_empty_file(datadir):
     with pytest.raises(ValueError):
         obtain_yaml_dicts(str(datadir / "includes_empty_file.yml"))

--- a/tests/test_include/relative_includes.yml
+++ b/tests/test_include/relative_includes.yml
@@ -1,0 +1,3 @@
+name: non_root_relative
+includes:
+  - proj1/relative_include.yml


### PR DESCRIPTION
This commit fix a problem when the jinja rendered root is missing for
includes in conda devenvs files.

#98