### PR TITLE
Add '-e' pip dependencies to merge test

### DIFF
--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -142,6 +142,9 @@ def test_merge_dependencies_version_specifications_pip_dependencies():
                     # issue #113
                     "--editable path/to/first/package",
                     "--editable path/to/second/package",
+                    # issue #118
+                    "-e ./path/to/first/package",
+                    "-e ./path/to/second/package",
                     # issue #92
                     "ConfigAndParse ==0.15.2",
                     # issue #91


### PR DESCRIPTION
This PR is making the tests more explicit and tests that (issue #118) '-e' editable pip dependencies don't get merged.

Note: This was already fixed in #114 and already included in v2.1.1