### PR TITLE
testing empty string in test_preprocess_selector_in_line

### DIFF
--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -215,6 +215,10 @@ def test_preprocess_selector_in_line():
     expected = f"{{% if linux %}}{line}{{% endif %}}"
     assert preprocess_selector_in_line(line) == expected
 
+    line = ""
+    expected = line
+    assert preprocess_selector_in_line(line) == expected
+
 
 def test_preprocess_selectors():
     template = textwrap.dedent(


### PR DESCRIPTION
This PR is a minor improvement to test `test_preprocess_selector_in_line`. It tests the case we provide an empty string to `preprocess_selector_in_line`.