### PR TITLE
Do not require environment variable for current OS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,11 @@ name: main
 
 on: [push, pull_request]
 
+# Cancel running jobs for the same workflow and branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 CHANGELOG
 =========
 
+UNRELEASED
+----------
+
+* Fix bug when an empty ``environment:`` key is declared in the ``environment.devenv.yml``file (`#164`_).
+
+.. _`#164`: https://github.com/ESSS/conda-devenv/pull/164
+
 2.3.0 (2022-03-07)
 ------------------
 

--- a/conda_devenv/devenv.py
+++ b/conda_devenv/devenv.py
@@ -307,6 +307,9 @@ def load_yaml_dict(filename):
 
     for filename, yaml_dict in all_yaml_dicts.items():
         environment_key_value = yaml_dict.get("environment", {})
+        if environment_key_value is None:
+            # The yaml has enironment variables for other OSes, but not the current one.
+            environment_key_value = {}
         if not isinstance(environment_key_value, dict):
             raise ValueError(
                 "The 'environment' key is supposed to be a dictionary, but you have the type "

--- a/conda_devenv/devenv.py
+++ b/conda_devenv/devenv.py
@@ -308,7 +308,7 @@ def load_yaml_dict(filename):
     for filename, yaml_dict in all_yaml_dicts.items():
         environment_key_value = yaml_dict.get("environment", {})
         if environment_key_value is None:
-            # The yaml has enironment variables for other OSes, but not the current one.
+            # Just an empty 'environment:' line will return None.
             environment_key_value = {}
         if not isinstance(environment_key_value, dict):
             raise ValueError(

--- a/tests/test_load_yaml_dict.py
+++ b/tests/test_load_yaml_dict.py
@@ -21,6 +21,12 @@ def test_load_yaml_dict_with_wrong_definition_at_environment_key(datadir):
     assert exception_message_start in str(e.value)
 
 
+def test_load_yaml_dict_empty_environment_key(datadir):
+    filename = str(datadir / "empty_environment.yml")
+    d = load_yaml_dict(filename)
+    assert d == ({"name": "foo"}, {})
+
+
 def test_load_yaml_dict_with_wrong_definition_at_environment_key_will_add_wrong_file_to_exception_message(
     datadir,
 ):

--- a/tests/test_load_yaml_dict/empty_environment.yml
+++ b/tests/test_load_yaml_dict/empty_environment.yml
@@ -1,0 +1,2 @@
+name: foo
+environment:


### PR DESCRIPTION
This PR allows the `environment` section in the environment.devenv.yml to have variables defined for other OSes (without requiring a variable to be defined for the current OS).

Related Issue
---

I am doing a bit of dependency management and started trying out `conda-devenv`. I am (re)creating my environment.devenv.yml on an OS-by-OS basis. Hence, I had just a single environment variable listed in `environment` (for Linux):
```yaml
environment:
    LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$CONDA_PREFIX/lib/  # [linux]
```

But, when testing on Windows, I received the following error:
```bash
(base) λ conda-devenv
Traceback (most recent call last):
  File "C:\Users\TalmoLab\miniconda3\Scripts\conda-devenv-script.py", line 9, in <module>
    sys.exit(main())
  File "C:\Users\TalmoLab\miniconda3\lib\site-packages\conda_devenv\devenv.py", line 596, in main
    return main_with_args_namespace(args_namespace)
  File "C:\Users\TalmoLab\miniconda3\lib\site-packages\conda_devenv\devenv.py", line 642, in main_with_args_namespace
    conda_yaml_dict, environment = load_yaml_dict(filename)
  File "C:\Users\TalmoLab\miniconda3\lib\site-packages\conda_devenv\devenv.py", line 311, in load_yaml_dict
    raise ValueError(
ValueError: The 'environment' key is supposed to be a dictionary, but you have the type '<class 'NoneType'>' at 'D:\social-leap-estimates-animal-poses\pull-requests\sleap\environment.devenv.yml'.
```

It seems the `environment` section was being read in as `None` when there were no environment variables listed for the current OS (but there were for other OSes).