### PR TITLE
Add aarch64 and arm64 selectors.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 CHANGELOG
 =========
 
-2.4.0
-----------
+2.4.0 (UNRELEASED)
+------------------
 
 * Added ``aarch64`` and ``arm64`` selectors (`#166`_).
 * Fixed bug when an empty ``environment:`` key is declared in the ``environment.devenv.yml``file (`#164`_).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,12 +2,14 @@
 CHANGELOG
 =========
 
-UNRELEASED
+2.4.0
 ----------
 
-* Fix bug when an empty ``environment:`` key is declared in the ``environment.devenv.yml``file (`#164`_).
+* Added ``aarch64`` and ``arm64`` selectors (`#166`_).
+* Fixed bug when an empty ``environment:`` key is declared in the ``environment.devenv.yml``file (`#164`_).
 
 .. _`#164`: https://github.com/ESSS/conda-devenv/pull/164
+.. _`#166`: https://github.com/ESSS/conda-devenv/pull/166
 
 2.3.0 (2022-03-07)
 ------------------

--- a/conda_devenv/devenv.py
+++ b/conda_devenv/devenv.py
@@ -84,6 +84,8 @@ def render_jinja(contents, filename, is_included):
         "platform": platform,
         "root": os.path.dirname(os.path.abspath(filename)),
         "sys": sys,
+        "aarch64": "aarch64" == platform.machine(),
+        "arm64": isosx and "arm64" == platform.machine(),
         "x86": "x86" == platform.machine(),
         "x86_64": "x86_64" == platform.machine(),
         "linux": islinux,

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -71,6 +71,10 @@ The following variables are available in the Jinja 2 namespace:
      - True if the platform is Windows and the Python architecture is 32-bit.
    * - ``win64``
      - True if the platform is Windows and the Python architecture is 64-bit.
+   * - ``aarch64``
+     - True if the platform is Linux on ARMv8 and the Python architecture is 64-bit.
+   * - ``arm64``
+     - True if the platform is macOS with Apple Silicon and the Python architecture is 64-bit.
    * - ``is_included``
      - True if the current file is processed because it was included by another file.
 

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -96,8 +96,12 @@ def test_jinja_arm64(monkeypatch):
     monkeypatch.setattr(platform, "machine", lambda: "aarch64")
     assert render_jinja(template, filename="", is_included=False) == "False"
 
+    monkeypatch.setattr(sys, "platform", "darwin")
     monkeypatch.setattr(platform, "machine", lambda: "arm64")
     assert render_jinja(template, filename="", is_included=False) == "True"
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    assert render_jinja(template, filename="", is_included=False) == "False"
 
     monkeypatch.setattr(platform, "machine", lambda: "x86")
     assert render_jinja(template, filename="", is_included=False) == "False"

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -74,8 +74,46 @@ def test_jinja_platform(monkeypatch):
     )
 
 
+def test_jinja_aarch64(monkeypatch):
+    template = "{{ aarch64 }}"
+
+    monkeypatch.setattr(platform, "machine", lambda: "aarch64")
+    assert render_jinja(template, filename="", is_included=False) == "True"
+
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+    assert render_jinja(template, filename="", is_included=False) == "False"
+
+    monkeypatch.setattr(platform, "machine", lambda: "x86")
+    assert render_jinja(template, filename="", is_included=False) == "False"
+
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    assert render_jinja(template, filename="", is_included=False) == "False"
+
+
+def test_jinja_arm64(monkeypatch):
+    template = "{{ arm64 }}"
+
+    monkeypatch.setattr(platform, "machine", lambda: "aarch64")
+    assert render_jinja(template, filename="", is_included=False) == "False"
+
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+    assert render_jinja(template, filename="", is_included=False) == "True"
+
+    monkeypatch.setattr(platform, "machine", lambda: "x86")
+    assert render_jinja(template, filename="", is_included=False) == "False"
+
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    assert render_jinja(template, filename="", is_included=False) == "False"
+
+
 def test_jinja_x86(monkeypatch):
     template = "{{ x86 }}"
+
+    monkeypatch.setattr(platform, "machine", lambda: "aarch64")
+    assert render_jinja(template, filename="", is_included=False) == "False"
+
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+    assert render_jinja(template, filename="", is_included=False) == "False"
 
     monkeypatch.setattr(platform, "machine", lambda: "x86")
     assert render_jinja(template, filename="", is_included=False) == "True"
@@ -86,6 +124,12 @@ def test_jinja_x86(monkeypatch):
 
 def test_jinja_x86_64(monkeypatch):
     template = "{{ x86_64 }}"
+
+    monkeypatch.setattr(platform, "machine", lambda: "aarch64")
+    assert render_jinja(template, filename="", is_included=False) == "False"
+
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+    assert render_jinja(template, filename="", is_included=False) == "False"
 
     monkeypatch.setattr(platform, "machine", lambda: "x86")
     assert render_jinja(template, filename="", is_included=False) == "False"


### PR DESCRIPTION
This commit adds the `aarch64` and `arm64` selectors to support Linux on ARM64 and macOS with Apple Silicon.