### PR TITLE
Better handling of missing lock file with --use-locks=yes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+UNRELEASED
+----------
+
+* Improved message with ``--use-locks=yes`` and no lock files are found.
+
 3.0.0 (2023-06-19)
 ------------------
 

--- a/src/conda_devenv/devenv.py
+++ b/src/conda_devenv/devenv.py
@@ -813,7 +813,7 @@ def main_with_args_namespace(args: argparse.Namespace) -> int | str | None:
                 raise UsageError(
                     f"lock file {e.lock_file} not found and --use-locks=yes, aborting."
                 )
-            return create_update_env(env_manager, args)
+        return create_update_env(env_manager, args)
 
     else:
         return create_update_env(env_manager, args)


### PR DESCRIPTION
The previous code was trying to go with the traditional "conda env update" route inside the exception handling for a missing lock file. This caused any errors during `create_update_env` to be chained to the `LockFileNotFoundError`, which is confusing.

This just moves the "conda env update" path outside the exception handling, so the exceptions no longer chain.