### PR TITLE
Fix platform selectors of included files when rendering lock files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+3.1.1 (2023-07-04)
+------------------
+
+* Fixed bug where the platform selectors of included ``devenv.yml`` files were not being honored when rendering lock files.
+
 3.1.0 (2023-06-30)
 ------------------
 

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -1,6 +1,7 @@
 import pytest
 import yaml
 
+from conda_devenv.devenv import CondaPlatform
 from conda_devenv.devenv import handle_includes
 from conda_devenv.devenv import render_jinja
 
@@ -8,9 +9,16 @@ from conda_devenv.devenv import render_jinja
 def obtain_yaml_dicts(root_yaml_filename):
     with open(root_yaml_filename) as f:
         contents = f.read()
-    contents = render_jinja(contents, filename=root_yaml_filename, is_included=False)
+    contents = render_jinja(
+        contents,
+        filename=root_yaml_filename,
+        is_included=False,
+        conda_platform=CondaPlatform.current(),
+    )
     root_yaml = yaml.safe_load(contents)
-    dicts = handle_includes(root_yaml_filename, root_yaml).values()
+    dicts = handle_includes(
+        root_yaml_filename, root_yaml, conda_platform=CondaPlatform.current()
+    ).values()
     dicts = list(dicts)
 
     # The list order does not matter, so we can"t use indices to fetch each item

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -18,6 +18,7 @@ def test_jinja_root() -> None:
         "{{root}}",
         filename=Path("path/to/file"),
         is_included=False,
+        conda_platform=CondaPlatform.current(),
     ) == os.path.abspath("path/to")
 
 
@@ -33,19 +34,34 @@ def test_jinja_os(monkeypatch) -> None:
     ).strip()
 
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False)
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
         == "variable is not set"
     )
 
     monkeypatch.setenv("ENV_VARIABLE", "1")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False)
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
         == "variable is set"
     )
 
     monkeypatch.setenv("ENV_VARIABLE", "2")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False)
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
         == "variable is not set"
     )
 
@@ -65,25 +81,47 @@ def test_jinja_sys(monkeypatch) -> None:
 
     monkeypatch.setattr(sys, "platform", "linux")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "linux!"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "linux!"
     )
 
     monkeypatch.setattr(sys, "platform", "windows")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False)
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
         == "windows!"
     )
 
     monkeypatch.setattr(sys, "platform", "darwin")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "others!"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "others!"
     )
 
 
 def test_jinja_platform(monkeypatch) -> None:
     template = "{{ platform.python_revision() }}"
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False)
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
         == platform.python_revision()
     )
 
@@ -92,21 +130,47 @@ def test_jinja_aarch64(monkeypatch) -> None:
     template = "{{ aarch64 }}"
 
     monkeypatch.setattr(platform, "machine", lambda: "aarch64")
-    assert render_jinja(template, filename=Path("foo.yml"), is_included=False) == "True"
+    assert (
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "True"
+    )
 
     monkeypatch.setattr(platform, "machine", lambda: "arm64")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(platform, "machine", lambda: "x86")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(platform, "machine", lambda: "x86_64")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
 
@@ -115,26 +179,58 @@ def test_jinja_arm64(monkeypatch) -> None:
 
     monkeypatch.setattr(platform, "machine", lambda: "aarch64")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(sys, "platform", "darwin")
     monkeypatch.setattr(platform, "machine", lambda: "arm64")
-    assert render_jinja(template, filename=Path("foo.yml"), is_included=False) == "True"
+    assert (
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "True"
+    )
 
     monkeypatch.setattr(sys, "platform", "win32")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(platform, "machine", lambda: "x86")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(platform, "machine", lambda: "x86_64")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
 
@@ -143,20 +239,46 @@ def test_jinja_x86(monkeypatch) -> None:
 
     monkeypatch.setattr(platform, "machine", lambda: "aarch64")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(platform, "machine", lambda: "arm64")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(platform, "machine", lambda: "x86")
-    assert render_jinja(template, filename=Path("foo.yml"), is_included=False) == "True"
+    assert (
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "True"
+    )
 
     monkeypatch.setattr(platform, "machine", lambda: "x86_64")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
 
@@ -165,37 +287,83 @@ def test_jinja_x86_64(monkeypatch) -> None:
 
     monkeypatch.setattr(platform, "machine", lambda: "aarch64")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(platform, "machine", lambda: "arm64")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(platform, "machine", lambda: "x86")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(platform, "machine", lambda: "x86_64")
-    assert render_jinja(template, filename=Path("foo.yml"), is_included=False) == "True"
+    assert (
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "True"
+    )
 
 
 def test_jinja_linux(monkeypatch) -> None:
     template = "{{ linux }}"
 
     monkeypatch.setattr(sys, "platform", "linux")
-    assert render_jinja(template, filename=Path("foo.yml"), is_included=False) == "True"
+    assert (
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "True"
+    )
 
     monkeypatch.setattr(sys, "platform", "win")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(sys, "platform", "darwin")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
 
@@ -205,11 +373,25 @@ def test_jinja_linux32(monkeypatch) -> None:
     monkeypatch.setattr(sys, "platform", "linux")
 
     monkeypatch.setattr(platform, "architecture", lambda: ("32bit", ""))
-    assert render_jinja(template, filename=Path("foo.yml"), is_included=False) == "True"
+    assert (
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "True"
+    )
 
     monkeypatch.setattr(platform, "architecture", lambda: ("64bit", ""))
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
 
@@ -220,11 +402,25 @@ def test_jinja_linux64(monkeypatch) -> None:
 
     monkeypatch.setattr(platform, "architecture", lambda: ("32bit", ""))
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(platform, "architecture", lambda: ("64bit", ""))
-    assert render_jinja(template, filename=Path("foo.yml"), is_included=False) == "True"
+    assert (
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "True"
+    )
 
 
 def test_jinja_osx(monkeypatch) -> None:
@@ -232,31 +428,73 @@ def test_jinja_osx(monkeypatch) -> None:
 
     monkeypatch.setattr(sys, "platform", "linux")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(sys, "platform", "win")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(sys, "platform", "darwin")
-    assert render_jinja(template, filename=Path("foo.yml"), is_included=False) == "True"
+    assert (
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "True"
+    )
 
 
 def test_jinja_unix(monkeypatch) -> None:
     template = "{{ unix }}"
 
     monkeypatch.setattr(sys, "platform", "linux")
-    assert render_jinja(template, filename=Path("foo.yml"), is_included=False) == "True"
+    assert (
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "True"
+    )
 
     monkeypatch.setattr(sys, "platform", "win")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(sys, "platform", "darwin")
-    assert render_jinja(template, filename=Path("foo.yml"), is_included=False) == "True"
+    assert (
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "True"
+    )
 
 
 def test_jinja_win(monkeypatch) -> None:
@@ -264,15 +502,35 @@ def test_jinja_win(monkeypatch) -> None:
 
     monkeypatch.setattr(sys, "platform", "linux")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(sys, "platform", "win")
-    assert render_jinja(template, filename=Path("foo.yml"), is_included=False) == "True"
+    assert (
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "True"
+    )
 
     monkeypatch.setattr(sys, "platform", "darwin")
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
 
@@ -282,11 +540,25 @@ def test_jinja_win32(monkeypatch) -> None:
     monkeypatch.setattr(sys, "platform", "win")
 
     monkeypatch.setattr(platform, "architecture", lambda: ("32bit", ""))
-    assert render_jinja(template, filename=Path("foo.yml"), is_included=False) == "True"
+    assert (
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "True"
+    )
 
     monkeypatch.setattr(platform, "architecture", lambda: ("64bit", ""))
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
 
@@ -297,11 +569,25 @@ def test_jinja_win64(monkeypatch) -> None:
 
     monkeypatch.setattr(platform, "architecture", lambda: ("32bit", ""))
     assert (
-        render_jinja(template, filename=Path("foo.yml"), is_included=False) == "False"
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "False"
     )
 
     monkeypatch.setattr(platform, "architecture", lambda: ("64bit", ""))
-    assert render_jinja(template, filename=Path("foo.yml"), is_included=False) == "True"
+    assert (
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "True"
+    )
 
 
 def test_preprocess_selector_in_line() -> None:
@@ -386,10 +672,10 @@ def test_render_jinja_with_preprocessing_selectors(monkeypatch, mode: str) -> No
         """
     ).strip()
 
-    def render_as_platform(platform: str, conda_platform: CondaPlatform | None) -> str:
+    def render_as_platform(platform: str, conda_platform: CondaPlatform) -> str:
         if mode == "patch-sys":
             monkeypatch.setattr(sys, "platform", platform)
-            conda_platform = None
+            conda_platform = CondaPlatform.current()
         else:
             assert mode == "use-conda-platform"
         return render_jinja(
@@ -409,19 +695,42 @@ def test_jinja_get_env(monkeypatch) -> None:
     template_with_default = "{{ get_env('PY', default='3.6') }}"
 
     monkeypatch.setenv("PY", "3.6")
-    assert render_jinja(template, filename=Path("foo.yml"), is_included=False) == "3.6"
+    assert (
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
+        == "3.6"
+    )
 
     monkeypatch.setenv("PY", "3.7")
     with pytest.raises(ValueError):
-        render_jinja(template, filename=Path("foo.yml"), is_included=False)
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
 
     monkeypatch.delenv("PY")
     with pytest.raises(ValueError):
-        render_jinja(template, filename=Path("foo.yml"), is_included=False)
+        render_jinja(
+            template,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
 
     monkeypatch.delenv("PY", raising=False)
     assert (
-        render_jinja(template_with_default, filename=Path("foo.yml"), is_included=False)
+        render_jinja(
+            template_with_default,
+            filename=Path("foo.yml"),
+            is_included=False,
+            conda_platform=CondaPlatform.current(),
+        )
         == "3.6"
     )
 
@@ -437,4 +746,5 @@ def test_jinja_invalid_template() -> None:
             ),
             filename=Path("foo.yml"),
             is_included=False,
+            conda_platform=CondaPlatform.current(),
         )

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -17,16 +17,31 @@ def test_create_and_update_lock_files(
     tmp_path: Path, mocker, monkeypatch, file_regression
 ) -> None:
     monkeypatch.chdir(tmp_path)
-    env_file = tmp_path / "environment.devenv.yml"
-    env_file.write_text(
+
+    base_env_file = tmp_path / "base.devenv.yml"
+    base_env_file.write_text(
         dedent(
             """
-            name: foo-py310
             channels:
             - conda-forge
             platforms:
             - win-64
             - linux-64
+            dependencies:
+            - pytest
+            - wincom  # [win]
+            - shmem  # [unix]
+            """
+        )
+    )
+
+    env_file = tmp_path / "environment.devenv.yml"
+    env_file.write_text(
+        dedent(
+            """
+            name: foo-py310
+            includes:
+            - {{ root }}/base.devenv.yml
             dependencies:
             - pytest
             - pywin32  # [win]

--- a/tests/test_locking/expected.linux-64.lock_environment.yml
+++ b/tests/test_locking/expected.linux-64.lock_environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
 - flock
 - pytest
+- shmem
 environment: {}
 name: foo-py310
 platforms:

--- a/tests/test_locking/expected.win-64.lock_environment.yml
+++ b/tests/test_locking/expected.win-64.lock_environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
 - pytest
 - pywin32
+- wincom
 environment: {}
 name: foo-py310
 platforms:


### PR DESCRIPTION
The platform selectors (`[win]`, `[linux]`, etc) for files included via `includes:` were not being honored when rendering lock files for all platforms.

The bug was that the `CondaPlatform` instance, which configures selectors explicitly, was not being passed along to the function which handled the `includes` directive.

To make this error less likely to happen again, the `conda_platform` parameter is no longer optional.

I plan to release directly from this branch, given this is just a bug fix.